### PR TITLE
Introduce BulkUpdatable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,18 @@ AllCops:
   TargetRubyVersion: 2.3
   DisplayCopNames: true
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - spec/**/*_spec.rb
+
+Metrics/AbcSize:
+  Exclude:
+    - lib/junk_drawer/rails/bulk_updatable.rb
+
+Metrics/MethodLength:
+  Exclude:
+    - lib/junk_drawer/rails/bulk_updatable.rb
+
 Metrics/BlockLength:
   Exclude:
     - junk_drawer.gemspec
@@ -61,6 +73,8 @@ Style/Send:
 
 RSpec/FilePath:
   IgnoreMethods: true
+  Exclude:
+    - spec/junk_drawer/rails/bulk_updatable_spec.rb
 
 RSpec/VerifiedDoubles:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
+addons:
+  postgresql: '9.4'
 before_install: gem install bundler -v 1.13.6
+before_script:
+  - createdb junk_drawer_test -U postgres
 script:
   - bundle exec rubocop
   - bundle exec rake

--- a/junk_drawer.gemspec
+++ b/junk_drawer.gemspec
@@ -21,14 +21,18 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
+  spec.add_development_dependency 'activerecord', '~> 4.2'
+  spec.add_development_dependency 'activesupport', '~> 4.2'
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'
+  spec.add_development_dependency 'pg', '~> 0.20'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.48.1'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.15.0'
   spec.add_development_dependency 'simplecov', '~> 0.14'
+  spec.add_development_dependency 'with_model', '~> 2.0'
 end

--- a/lib/junk_drawer/rails.rb
+++ b/lib/junk_drawer/rails.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative '../junk_drawer'
+require_relative 'rails/bulk_updatable'

--- a/lib/junk_drawer/rails/bulk_updatable.rb
+++ b/lib/junk_drawer/rails/bulk_updatable.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'active_support/all'
+require 'active_record'
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module JunkDrawer
+  # module to allow bulk updates for `ActiveRecord` models
+  module BulkUpdatable
+    ATTRIBUTE_TYPE_TO_POSTGRES_CAST = {
+      datetime: '::timestamp',
+      hstore: '::hstore',
+      boolean: '::boolean',
+      jsonb: '::jsonb',
+    }.freeze
+
+    POSTGRES_VALUE_CASTERS = {
+      hstore: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Hstore.new,
+      jsonb: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb.new,
+    }.freeze
+
+    def bulk_update(objects)
+      objects = objects.select(&:changed?)
+      return unless objects.any?
+
+      changed_attributes = extract_changed_attributes(objects)
+      query = build_query_for(objects, changed_attributes)
+      connection.execute(query)
+    end
+
+  private
+
+    def extract_changed_attributes(objects)
+      now = Time.zone.now
+      objects.each { |object| object.updated_at = now }
+
+      objects.flat_map(&:changed).uniq
+    end
+
+    def build_query_for(objects, attributes)
+      object_values = objects.map do |object|
+        sanitized_values(object, attributes)
+      end.join(', ')
+
+      assignment_query = attributes.map do |attribute|
+        quoted_column_name = connection.quote_column_name(attribute)
+        "#{quoted_column_name} = tmp_table.#{quoted_column_name}"
+      end.join(', ')
+
+      <<-SQL
+        UPDATE #{table_name}
+        SET #{assignment_query}
+        FROM (VALUES #{object_values}) AS tmp_table(id, #{attributes.join(', ')})
+        WHERE #{table_name}.id = tmp_table.id
+      SQL
+    end
+
+    def sanitized_values(object, attributes)
+      postgres_types = attributes.map do |attribute|
+        attribute_type = columns_hash[attribute.to_s].type
+        "?#{ATTRIBUTE_TYPE_TO_POSTGRES_CAST[attribute_type]}"
+      end
+
+      postgres_values = attributes.map do |attribute|
+        value = object[attribute]
+        attribute_type = columns_hash[attribute.to_s].type
+        caster = POSTGRES_VALUE_CASTERS[attribute_type]
+
+        caster ? caster.type_cast_for_database(value) : value
+      end
+
+      sanitize_sql_array(
+        ["(?, #{postgres_types.join(', ')})", object.id, *postgres_values],
+      )
+    end
+  end
+end

--- a/spec/junk_drawer/rails/bulk_updatable_spec.rb
+++ b/spec/junk_drawer/rails/bulk_updatable_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+RSpec.describe JunkDrawer::BulkUpdatable, '.bulk_update' do
+  with_model :BulkUpdatableModel do
+    table do |t|
+      t.string :thing
+      t.boolean :bool_thing
+      t.hstore :data_thing, default: {}, null: false
+      t.datetime :some_time
+      t.jsonb :data_thing, default: {}, null: false
+      t.datetime :updated_at
+    end
+
+    model do
+      extend JunkDrawer::BulkUpdatable
+    end
+  end
+
+  let(:models) do
+    [
+      BulkUpdatableModel.create!(thing: ''),
+      BulkUpdatableModel.create!(thing: ''),
+    ]
+  end
+
+  it 'updates the attribute on all the models' do
+    models.each_with_index do |model, index|
+      model.thing = "thing_#{index}"
+    end
+
+    BulkUpdatableModel.bulk_update(models)
+    models.each(&:reload)
+
+    expect(models[0].thing).to eq 'thing_0'
+    expect(models[1].thing).to eq 'thing_1'
+  end
+
+  it 'only updates the models with changes' do
+    models.first.thing = 'changed attr!'
+
+    expect do
+      BulkUpdatableModel.bulk_update(models)
+    end.to change { models.first.updated_at }
+      .and not_change { models.last.updated_at }
+  end
+
+  it 'updates the updated_at on the models' do
+    expect do
+      models.each_with_index do |model, index|
+        model.thing = "thing_#{index}"
+      end
+
+      BulkUpdatableModel.bulk_update(models)
+    end.to change { models.first.reload.updated_at }
+      .and change { models.last.reload.updated_at }
+  end
+
+  it "doesn't blow up when input is empty array" do
+    expect do
+      BulkUpdatableModel.bulk_update([])
+    end.not_to raise_error
+  end
+
+  it 'works for hstore datatypes' do
+    models.each_with_index do |model, index|
+      model.data_thing["key_#{index}"] = "thing_data_#{index}"
+    end
+
+    BulkUpdatableModel.bulk_update(models)
+    models.each(&:reload)
+
+    expect(models[0].data_thing).to eq('key_0' => 'thing_data_0')
+    expect(models[1].data_thing).to eq('key_1' => 'thing_data_1')
+  end
+
+  it 'works for jsonb datatypes' do
+    models.each_with_index do |model, index|
+      model.data_thing = { key: index }
+    end
+
+    BulkUpdatableModel.bulk_update(models)
+    models.each(&:reload)
+
+    expect(models[0].data_thing).to eq('key' => 0)
+    expect(models[1].data_thing).to eq('key' => 1)
+  end
+
+  it 'works for boolean datatypes' do
+    models.first.bool_thing = true
+    models.last.bool_thing = false
+
+    BulkUpdatableModel.bulk_update(models)
+    models.each(&:reload)
+
+    expect(models.first.bool_thing).to be true
+    expect(models.last.bool_thing).to be false
+  end
+
+  it 'works for datetime datatypes' do
+    now = Time.zone.now.round
+    before = 3.days.ago.round
+
+    models.first.some_time = now
+    models.last.some_time = before
+
+    BulkUpdatableModel.bulk_update(models)
+    models.each(&:reload)
+
+    expect(models.first.some_time.round).to eq now
+    expect(models.last.some_time.round).to eq before
+  end
+
+  it 'can bulk update multiple columns at once' do
+    models.first.bool_thing = true
+    models.first.thing = 'weeehooo'
+    models.last.bool_thing = false
+    models.last.thing = 'plop'
+
+    BulkUpdatableModel.bulk_update(models)
+    models.each(&:reload)
+
+    expect(models.first.bool_thing).to be true
+    expect(models.first.thing).to eq 'weeehooo'
+    expect(models.last.bool_thing).to be false
+    expect(models.last.thing).to eq 'plop'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,24 @@
 # frozen_string_literal: true
 
-require_relative '../lib/junk_drawer'
+require 'with_model'
+
+require_relative '../lib/junk_drawer/rails'
 require_relative 'support/invoke_matcher'
+
+Time.zone = 'Eastern Time (US & Canada)'
+
+ActiveRecord::Base.establish_connection(
+  username: 'postgres',
+  adapter: 'postgresql',
+  database: 'junk_drawer_test',
+  host: 'localhost',
+)
 
 RSpec.configure do |config|
   config.order = :random
   config.filter_run_when_matching :focus
+
+  config.extend(WithModel)
 end
+
+RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
This introduces a `BulkUpdatable` module which can be included in
`ActiveRecord` models. I added a nested `rails/` directory which can be
optionally required. If a user wants only the plain ruby stuff, they can
`require 'junk_drawer'`. If they want both they can `require
'junk_drawer/rails'`.